### PR TITLE
Add gorilla/websocket to list of packages provided

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -8,6 +8,7 @@
     <li><a href="/pkg/schema">gorilla/schema</a> converts form values to a struct.</li>
     <li><a href="/pkg/securecookie">gorilla/securecookie</a> encodes and decodes authenticated and optionally encrypted cookie values.</li>
     <li><a href="/pkg/sessions">gorilla/sessions</a> saves cookie and filesystem sessions and allows custom session backends.</li>
+    <li><a href="/pkg/websocket">gorilla/websocket</a> implements the WebSocket protocol defined in <a href="http://tools.ietf.org/html/rfc6455">RFC 6455</a>.</li>
   </ul>
 
   <h2>Installation</h2>


### PR DESCRIPTION
Currently the websocket package is not listed on http://gorillatoolkit.org, even though http://www.gorillatoolkit.org/pkg/websocket is available, and it appears to be the only top-level (non-helper) package missing.
