### PR TITLE
Add handlers to the list of gorilla packages

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -10,6 +10,7 @@
     <li><a href="/pkg/sessions">gorilla/sessions</a> saves cookie and filesystem sessions and allows custom session backends.</li>
     <li><a href="/pkg/websocket">gorilla/websocket</a> implements the WebSocket protocol defined in <a href="http://tools.ietf.org/html/rfc6455">RFC 6455</a>.</li>
     <li><a href="/pkg/csrf">gorilla/csrf</a> provides Cross Site Request Forgery (CSRF) prevention middleware.</li>
+    <li><a href="/pkg/handlers">gorilla/handlers</a> is a collection of useful handlers for Go's net/http package.</li>
   </ul>
 
   <h2>Installation</h2>


### PR DESCRIPTION
It seems like it'd be useful to have the handlers on the main page of the site. I didn't find handlers until I browsed the github org. 
