### PR TITLE
Fix GoDoc link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -41,7 +41,7 @@
     <footer>
       <p>
         Hosting by <a href="http://code.google.com/appengine/">Google App Engine</a>.
-        Docs by <a href="http://go.pkgdoc.org/">GoPkgDoc</a>.
+        Docs by <a href="https://godoc.org/">GoDoc</a>.
         Gorilla font by <a href="https://plus.google.com/107807505287232434305/about">Vernon Adams</a>.
         Gorilla icon by <a href="http://www.graphics-and-desktop-icons.com/">Martin Bérubé</a>.
       </p>


### PR DESCRIPTION
http://go.pkgdoc.org/ is Already deprecated.