### PR TITLE
bugfix: redirect /pkg/{name} to GitHub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/gorilla/site
 
+go 1.14
+
 require (
+	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	google.golang.org/appengine v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225 h1:kNX+jCowfMYzvlSvJu5pQWEmyWFrBXJ3PBy10xKMXK8=

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,24 +14,24 @@
           <li{{if eq .Section "home"}} class="active"{{end}}>
             <a href="/" title="home of the fearless gorilla, the golang web toolkit">Home</a>
           </li>
-          <li{{if eq .Section "pkg"}} class="active"{{end}}>
+          <!--<li{{if eq .Section "pkg"}} class="active"{{end}}>
             <a href="/pkg/" title="api documentation">Packages</a>
           </li>
+          -->
           <li>
-            <a href="https://github.com/gorilla/" title="repository and issue tracker">Source</a>
+            <a href="https://github.com/gorilla/" title="repository and issue tracker">Source (GitHub)</a>
           </li>
           <li>
             <a href="https://groups.google.com/group/gorilla-web" title="mailing list">Community</a>
           </li>
-          <li>
-            <a href="https://plus.google.com/116448763101158824911/posts" title="google+ page">News</a>
-          </li>
+          <!--
           {{/*<li{{if eq .Section "src"}} class="active"{{end}}>
             <a href="/src/" title="code repository and issue tracker">Source</a>
           </li>
           <li{{if eq .Section "people"}} class="active"{{end}}>
             <a href="/people" title="community links">People</a>
           </li>*/}}
+          -->
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
- Redirects `/pkg/{name}` to `github.com/gorilla/{name}`
- Redirects `/pkg/` to `github.com/gorilla`
- Removes broken people and community links