### PR TITLE
remove reference to deprecated + archived "gorilla/context"

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -1,7 +1,6 @@
 {{define "body"}}
   <p>Gorilla is a web toolkit for the <a href="http://golang.org/">Go programming language</a>. Currently these packages are available:</p>
   <ul>
-    <li><a href="/pkg/context">gorilla/context</a> stores global request variables.</li>
     <li><a href="/pkg/mux">gorilla/mux</a> is a powerful URL router and dispatcher.</li>
     <li><a href="/pkg/reverse">gorilla/reverse</a> produces reversible regular expressions for regexp-based muxes.</li>
     <li><a href="/pkg/rpc">gorilla/rpc</a> implements RPC over HTTP with codec for <a href="/pkg/rpc/json">JSON-RPC</a>.</li>


### PR DESCRIPTION
...it's the first link on the page, and doesn't represent the project well.
