### PR TITLE
Update community link descriptions and add slack channel

### DIFF
--- a/themes/gorillawebtoolkit/layouts/index.html
+++ b/themes/gorillawebtoolkit/layouts/index.html
@@ -118,18 +118,21 @@
 <p>Or clone a <a href="https://github.com/gorilla/" target="_blank">repository</a> and use the source code directly:</p>
 <pre>$ git clone https://github.com/gorilla/mux.git</pre>
 
-<h2 class="pb-2 border-bottom">Community</h2>
+
+<h2 id="community" class="pb-2 border-bottom">Community</h2>
 <div class="container px-4 py-2" id="packages-grid">
 
 
-	<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-2 g-2 py-3 text-light">
+	<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-3 g-3 py-3 text-light">
+
+
 		<div class="col d-flex align-items-start">
 			<div class="border border-1 rounded p-2 bg-dark h-100 position-relative">
-				<h4 class="fw-bold mb-1">Mailing List</h4>
-				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Fermentum posuere urna nec tincidunt praesent semper feugiat.</p>
+				<h4 class="fw-bold mb-1">Slack</h4>
+				<p>Participate in near real-time conversations with other Gorilla web toolkit community members. Ask questions, get answers, build relationships.</p>
 				<div class="text-end">
-					<a href="https://groups.google.com/g/gorilla-web" target="_blank" class="btn btn-warning btn-sm">
-						Join the Community
+					<a href="https://gophers.slack.com/archives/C66HMHQHL" target="_blank" class="btn btn-warning btn-sm">
+						Join the Channel
 					</a>
 				</div>
 			</div>
@@ -137,7 +140,7 @@
 		<div class="col d-flex align-items-start">
 			<div class="border border-1 rounded p-2 bg-dark h-100 position-relative">
 				<h4 class="fw-bold mb-1">GitHub Discussions</h4>
-				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Fermentum posuere urna nec tincidunt praesent semper feugiat.</p>
+				<p>Join in-depth discussions about the Gorilla web toolkit, propose new features, debate to your hearts content, and help shape our future!</p>
 				<div class="text-end">
 					<a href="https://github.com/orgs/gorilla/discussions" target="_blank" class="btn btn-warning btn-sm">
 						Join the Discussion
@@ -145,7 +148,17 @@
 				</div>
 			</div>
 		</div>
-
+		<div class="col d-flex align-items-start">
+			<div class="border border-1 rounded p-2 bg-dark h-100 position-relative">
+				<h4 class="fw-bold mb-1">Mailing List</h4>
+				<p>Do you love your email client and want to spend more time using it? Then this is the place for you! Ask questions and get announcements all from the safety of your inbox.</p>
+				<div class="text-end">
+					<a href="https://groups.google.com/g/gorilla-web" target="_blank" class="btn btn-warning btn-sm">
+						Join the Community
+					</a>
+				</div>
+			</div>
+		</div>
 	</div>
 </div>
 

--- a/themes/gorillawebtoolkit/layouts/partials/header.html
+++ b/themes/gorillawebtoolkit/layouts/partials/header.html
@@ -12,7 +12,7 @@
 				<a class="nav-link" target="_blank" href="https://github.com/gorilla">Source</a>
 			</li>
 			<li class="nav-item">
-				<a class="nav-link" target="_blank" href="https://groups.google.com/g/gorilla-web">Community</a>
+				<a class="nav-link" target="_blank" href="#community">Community</a>
 			</li>
 		</ul>
 	</div>


### PR DESCRIPTION
- Replace lorem ipsum text in community link descriptions
- Add community section for #gorilla channel on gophers.slack.com
- Update top Community link to point to the community section of the page